### PR TITLE
Change metabox from text to textarea to allow URLs to be inserted

### DIFF
--- a/inc/functions-admin.php
+++ b/inc/functions-admin.php
@@ -31,7 +31,7 @@ function currency_application_metaboxes() {
 					'name' => 'Currency converter application disclaimer',
 					'desc' => '',
 					'id'   => 'currency_application_disclaimer',
-					'type' => 'text',
+					'type' => 'textarea',
 					'std'  => ''
 				)
 			)


### PR DESCRIPTION
Hi @ARBaynes,

I changed the disclaimer metabox on the currency converter to a textarea so that the content editors can add URL's to the disclaimer. 

Thanks